### PR TITLE
fixed mysql-pvc.yml: annotation caused error

### DIFF
--- a/spring-boot-example/kubernetes/mysql-pvc.yaml
+++ b/spring-boot-example/kubernetes/mysql-pvc.yaml
@@ -16,8 +16,6 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: mysql-pvc
-  annotations:
-    volume.beta.kubernetes.io/storage-class: standard
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
This annotation causes an error on Digital Ocean Kube and minikube that causes the persistent volume to crash on kube versions of 1.16 or greater.